### PR TITLE
add custom template dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Option `--item` with value `CLASSNAME` is supported for generating pipelines, wh
 
 Option `--settings` is also supported for pipelines, extension, middlewares and spider middlewares. It has an optional integer value `PRIORITY` that adds specified priority. If only `-s` is used, settings file will be `settings.py`.
 
-Option `--file` is used for specifying settings file name (or class). You can use spider file for adding newly generated class to spiders' `custom_settings` property. If you enumerate file names (or class names) using `,` (like `-f SomeSpider,AnotherSpider`) - script will add generated class to custom_settings of each file. If only `-f` is used, will be used default priority (300).
+(experimental) Option `--file` is used for specifying settings file name (or class). You can use spider file for adding newly generated class to spiders' `custom_settings` property. If you enumerate file names (or class names) using `,` (like `-f SomeSpider,AnotherSpider`) - script will add generated class to custom_settings of each file. If only `-f` is used, will be used default priority (300).
 
 Option `--terminal` will output 'custom_settings' code to terminal.
+
+Option `--custom` can be used for custom template folder path. Template names should be like `{}.py.mako`. Option will enable usage of TEMPLATES_MODULE setting from projects` settings.py. If this setting is not defined, will cause exception.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The first argument (`spider`) is a type of class file to be generated, and can b
 - middleware
 - model
 - pipeline
-- spider_middleware
 - spider
 
 The second argument is class name.
@@ -34,9 +33,11 @@ Also for `pipeline` and `spider` class an option `--rabbit` can be used to add R
 
 Option `--item` with value `CLASSNAME` is supported for generating pipelines, which adds an import and type-check for a provided item class to the resulting code.
 
-Option `--settings` is also supported for pipelines, extension, middlewares and spider middlewares. It has an optional integer value `PRIORITY` that adds specified priority (default 300). It indicates a class to be added to scrapy project (or spider) settings.
+Option `--settings` is also supported for pipelines, extension, middlewares and spider middlewares. It has an optional integer value `PRIORITY` that adds specified priority. If only `-s` is used, settings file will be `settings.py`.
 
-Option `--file` can be used when using `--settings` for specifying settings file name. Default value is `settings.py` file. You use set spider file for adding newly generated class to spiders' `custom_settings` property.
+Option `--file` is used for specifying settings file name (or class). You can use spider file for adding newly generated class to spiders' `custom_settings` property. If you enumerate file names (or class names) using `,` (like `-f SomeSpider,AnotherSpider`) - script will add generated class to custom_settings of each file. If only `-f` is used, will be used default priority (300).
+
+Option `--terminal` will output 'custom_settings' code to terminal.
 
 ## Installation
 

--- a/scrapy_new/new.py
+++ b/scrapy_new/new.py
@@ -207,6 +207,10 @@ class NewCommand(ScrapyCommand):
             "pipeline": ["pipelines"],
             "spider_middleware": ["middlewares"],
             "spider": ["spiders"],
+            "helper": ["helpers"],
+            "rabbitmq": ["rabbitmq"],
+            "pm2": ["pm2"],
+            "loader": ["loaders"],
         }
 
         template_type = args[0]

--- a/scrapy_new/new.py
+++ b/scrapy_new/new.py
@@ -90,6 +90,15 @@ class NewCommand(ScrapyCommand):
             help="enable debug output for this command",
         )
 
+        parser.add_option(
+            "-c",
+            "--custom",
+            action="store_true",
+            dest="custom_templates_dir",
+            default=False,
+            help="enable using of custom template modules",
+        )
+
     def get_settings_dict(self, setting_str: Match) -> dict:
         """Returns object from setting string"""
         capture = setting_str.group(0)
@@ -206,6 +215,18 @@ class NewCommand(ScrapyCommand):
             print(f"ERROR: unsupported template type: {template_type}")
             print("supported types: {}".format(repr(SUPPORTED_TEMPLATE_TYPES)))
             sys.exit(1)
+
+        if opts.custom_templates_dir:
+            # feature for adding custom templates
+            # uses TEMPLATES_MODULE setting in settings.py
+            if os.path.exists(self.default_settings_filename):
+                from settings import TEMPLATES_MODULE  # isort:skip
+
+                tmp = os.path.join(TEMPLATES_MODULE, "{}.py.mako".format(template_type))
+                if os.path.exists(tmp):
+                    templates_dir = TEMPLATES_MODULE
+            else:
+                raise UsageError(f"No settings.py in project!")
 
         template_name = os.path.join(templates_dir, "{}.py.mako".format(template_type))
         template = Template(filename=template_name)

--- a/scrapy_new/new.py
+++ b/scrapy_new/new.py
@@ -215,11 +215,6 @@ class NewCommand(ScrapyCommand):
 
         template_type = args[0]
 
-        if template_type not in SUPPORTED_TEMPLATE_TYPES:
-            print(f"ERROR: unsupported template type: {template_type}")
-            print("supported types: {}".format(repr(SUPPORTED_TEMPLATE_TYPES)))
-            sys.exit(1)
-
         if opts.custom_templates_dir:
             # feature for adding custom templates
             # uses TEMPLATES_MODULE setting in settings.py
@@ -229,8 +224,16 @@ class NewCommand(ScrapyCommand):
                 tmp = os.path.join(TEMPLATES_MODULE, "{}.py.mako".format(template_type))
                 if os.path.exists(tmp):
                     templates_dir = TEMPLATES_MODULE
+                    SUPPORTED_TEMPLATE_TYPES.extend(
+                        name.split(".")[0] for name in os.listdir(templates_dir)
+                    )
             else:
                 raise UsageError(f"No settings.py in project!")
+
+        if template_type not in SUPPORTED_TEMPLATE_TYPES:
+            print(f"ERROR: unsupported template type: {template_type}")
+            print("supported types: {}".format(repr(SUPPORTED_TEMPLATE_TYPES)))
+            sys.exit(1)
 
         template_name = os.path.join(templates_dir, "{}.py.mako".format(template_type))
         template = Template(filename=template_name)

--- a/scrapy_new/templates/command.py.mako
+++ b/scrapy_new/templates/command.py.mako
@@ -16,7 +16,6 @@ class ${class_name}(BaseCommand):
     def __init__(self):
         super().__init__()
         self.engine = None
-        self.session = None
         % if use_rabbit:
         self.connection = None
         self.channel = None
@@ -26,7 +25,6 @@ class ${class_name}(BaseCommand):
     def connect(self) -> None:
         """Connects to database and rabbitmq (optionally)"""
         self.engine = create_engine(mysql_connection_string())
-        self.session = Session(self.engine)
         % if use_rabbit:
 
         queue_name = self.settings.get("QUEUE_NAME")  # LINKS_QUEUE or SAVER_QUEUE
@@ -57,4 +55,3 @@ class ${class_name}(BaseCommand):
         self.channel.close()
         self.connection.close()
         % endif
-        self.session.close()

--- a/scrapy_new/templates/model.py.mako
+++ b/scrapy_new/templates/model.py.mako
@@ -6,17 +6,10 @@ from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.orm import relationship
 
 from .base import Base
-from .json_serializable import JSONSerializable
+from .mixins import JSONSerializable, MysqlPrimaryKeyMixin, MysqlTimestampsMixin
 
 
-class ${class_name}(Base, JSONSerializable):
+class ${class_name}(Base, JSONSerializable, MysqlPrimaryKeyMixin, MysqlTimestampsMixin):
     __tablename__ = "${table_name}"
 
-    id = Column("id", BIGINT(unsigned=True), primary_key=True, autoincrement=True)
-
-    created_at = Column("created_at", TIMESTAMP, server_default=func.now())
-    updated_at = Column(
-        "updated_at",
-        TIMESTAMP,
-        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
-    )
+    # TODO

--- a/scrapy_new/templates/pipeline.py.mako
+++ b/scrapy_new/templates/pipeline.py.mako
@@ -1,12 +1,15 @@
 ## -*- coding: utf-8 -*-
 # -*- coding: utf-8 -*-
+from scrapy import Item, Spider
+
 % if use_rabbit:
 from helpers import PikaBlockingConnection, mysql_connection_string
+% else:
+from helpers import mysql_connection_string
 % endif
 % if item_class:
 from items import ${item_class}
 % endif
-from scrapy import Item, Spider
 from sqlalchemy import create_engine
 from sqlalchemy.exc import DataError, IntegrityError, InvalidRequestError
 from sqlalchemy.orm import Session
@@ -15,28 +18,26 @@ from sqlalchemy.orm import Session
 class ${class_name}:
     def __init__(self):
         self.engine = create_engine(mysql_connection_string())
-        self.session = None
         % if use_rabbit:
         self.connection = None
         self.channel = None
         % endif
 
     def open_spider(self, spider: Spider) -> None:
-        self.session = Session(self.engine)
         % if use_rabbit:
-
         queue_name = spider.settings.get("SAVER_QUEUE")
         rabbitmq = PikaBlockingConnection(queue_name, spider.settings)
         self.connection = rabbitmq.rabbit_connection
         self.channel = rabbitmq.rabbit_channel
         self.channel.queue_declare(queue=queue_name, durable=True)
+        % else:
+        pass
         % endif
 
     def process_item(self, item: Item, spider: Spider) -> Item:
         % if item_class:
         if isinstance(item, ${item_class}):
-            return item
-
+            pass  # TODO process item
         % endif
         return item
 
@@ -44,5 +45,6 @@ class ${class_name}:
         % if use_rabbit:
         self.channel.close()
         self.connection.close()
+        % else:
+        pass
         % endif
-        self.session.close()

--- a/scrapy_new/templates/spider.py.mako
+++ b/scrapy_new/templates/spider.py.mako
@@ -3,15 +3,16 @@
 from typing import Iterator, Union
 
 import scrapy
+from scrapy import Item, Request, Spider, signals
+from scrapy.crawler import Crawler
+from scrapy.http import Response
 % if use_rabbit:
+
 from pika.spec import BasicProperties
 from rabbitmq import RabbitSpider
 % endif
-from scrapy import Item, Request, signals
-from scrapy.crawler import Crawler
-from scrapy.http import Response
 <%
-    ancestors = ["scrapy.Spider"]
+    ancestors = ["Spider"]
     if use_rabbit:
         ancestors.append("RabbitSpider")
 
@@ -30,7 +31,7 @@ class ${class_name}(${ancestors}):
         return spider
 
     def __init__(self, *args, **kwargs):
-        scrapy.Spider.__init__(self, *args, **kwargs)
+        Spider.__init__(self, *args, **kwargs)
         % if use_rabbit:
         RabbitSpider.__init__(self, *args, **kwargs)
         % endif


### PR DESCRIPTION
edited:
- add classname settings ('-f SpiderOne' instead of '-f *path*/spiders/spider_one.py')
- add multiple file settings (like 'poetry run scrapy new pipeline SomeName -s 10 -f SpiderOne,SpiderTwo' 
- add readme details on latest additions
- del self.session in templates (fix #12 )
- sort imports of some templates, update them

(upd 08 apr 2020)
- added TEMPLATES_MODULE setting support (uses settings.py) #14 , #1 
- added extending available templates list by ones, which are in custom folder (but still limited to foldername mapping in new.py)